### PR TITLE
Fix parameter types in HTTP lib

### DIFF
--- a/src/net/http.h
+++ b/src/net/http.h
@@ -42,12 +42,12 @@ HttpRequest *http_request_create(HttpRequestMethod method);
 void		http_request_destroy(HttpRequest *req);
 
 /* Assume that uri is null-terminated */
-void		http_request_set_uri(HttpRequest *req, char *uri);
+void		http_request_set_uri(HttpRequest *req, const char *uri);
 void		http_request_set_version(HttpRequest *req, HttpRequestVersion version);
 
 /* Assume that name and value are null-terminated */
-void		http_request_set_header(HttpRequest *req, char *name, char *value);
-void		http_request_set_body(HttpRequest *req, char *body, int body_len);
+void		http_request_set_header(HttpRequest *req, const char *name, const char *valuue);
+void		http_request_set_body(HttpRequest *req, const char *body, size_t body_len);
 
 /*  Serialize the request into char *dst. Return the length of request in optional size pointer*/
 const char *http_request_build(HttpRequest *req, size_t *buf_size);
@@ -71,5 +71,5 @@ int			http_response_state_status_code(HttpResponseState *state);
 HttpHeader *http_response_state_headers(HttpResponseState *state);
 
 /*  Returns false if encountered an error during parsing */
-bool		http_response_state_parse(HttpResponseState *state, int bytes);
+bool		http_response_state_parse(HttpResponseState *state, size_t bytes);
 #endif							/* TIMESCALEDB_HTTP_H */

--- a/src/net/http_request.c
+++ b/src/net/http_request.c
@@ -14,11 +14,18 @@
 #define NEW_LINE	'\n'
 
 /*  So that http_response.c can find this function */
-HttpHeader *http_header_create(char *name, int name_len, char *value, int value_len, HttpHeader *next);
+HttpHeader *http_header_create(const char *name,
+				   size_t name_len,
+				   const char *value,
+				   size_t value_len,
+				   HttpHeader *next);
 
 HttpHeader *
-http_header_create(char *name, int name_len, char *value, int value_len, HttpHeader
-				   *next)
+http_header_create(const char *name,
+				   size_t name_len,
+				   const char *value,
+				   size_t value_len,
+				   HttpHeader *next)
 {
 	HttpHeader *new_header = palloc(sizeof(HttpHeader));
 
@@ -43,11 +50,11 @@ typedef struct HttpRequest
 {
 	HttpRequestMethod method;
 	char	   *uri;
-	int			uri_len;
+	size_t		uri_len;
 	HttpRequestVersion version;
 	HttpHeader *headers;
 	char	   *body;
-	int			body_len;
+	size_t		body_len;
 	MemoryContext context;
 } HttpRequest;
 
@@ -73,8 +80,9 @@ http_request_init(HttpRequest *req, HttpRequestMethod method)
 HttpRequest *
 http_request_create(HttpRequestMethod method)
 {
-	MemoryContext request_context = AllocSetContextCreate(
-														  CurrentMemoryContext, "Http Request", ALLOCSET_DEFAULT_SIZES);
+	MemoryContext request_context = AllocSetContextCreate(CurrentMemoryContext,
+														  "Http Request",
+														  ALLOCSET_DEFAULT_SIZES);
 	MemoryContext old = MemoryContextSwitchTo(request_context);
 
 	HttpRequest *req = palloc(sizeof(HttpRequest));
@@ -95,7 +103,7 @@ http_request_destroy(HttpRequest *req)
 }
 
 void
-http_request_set_uri(HttpRequest *req, char *uri)
+http_request_set_uri(HttpRequest *req, const char *uri)
 {
 	MemoryContext old = MemoryContextSwitchTo(req->context);
 	int			uri_len = strlen(uri);
@@ -114,7 +122,7 @@ http_request_set_version(HttpRequest *req, HttpRequestVersion version)
 }
 
 void
-http_request_set_header(HttpRequest *req, char *name, char *value)
+http_request_set_header(HttpRequest *req, const char *name, const char *value)
 {
 	MemoryContext old = MemoryContextSwitchTo(req->context);
 	int			name_len = strlen(name);
@@ -127,7 +135,7 @@ http_request_set_header(HttpRequest *req, char *name, char *value)
 }
 
 void
-http_request_set_body(HttpRequest *req, char *body, int body_len)
+http_request_set_body(HttpRequest *req, const char *body, size_t body_len)
 {
 	MemoryContext old = MemoryContextSwitchTo(req->context);
 

--- a/src/net/http_response.c
+++ b/src/net/http_response.c
@@ -11,7 +11,7 @@
 #define NEW_LINE		'\n'
 #define SEP_CHAR		':'
 
-extern HttpHeader *http_header_create(char *name, int name_len, char *value, int value_len, HttpHeader *next);
+extern HttpHeader *http_header_create(const char *name, size_t name_len, const char *value, size_t value_len, HttpHeader *next);
 
 typedef enum HttpParseState
 {
@@ -53,8 +53,9 @@ http_response_state_init(HttpResponseState *state)
 HttpResponseState *
 http_response_state_create()
 {
-	MemoryContext context = AllocSetContextCreate(
-												  CurrentMemoryContext, "Http Response", ALLOCSET_DEFAULT_SIZES);
+	MemoryContext context = AllocSetContextCreate(CurrentMemoryContext,
+												  "Http Response",
+												  ALLOCSET_DEFAULT_SIZES);
 	MemoryContext old = MemoryContextSwitchTo(context);
 	HttpResponseState *ret = palloc(sizeof(HttpResponseState));
 
@@ -128,7 +129,7 @@ http_response_state_headers(HttpResponseState *state)
 }
 
 static void
-http_parse_status(HttpResponseState *state, char next)
+http_parse_status(HttpResponseState *state, const char next)
 {
 	char		version[128];
 	char		raw_buf[state->parse_offset + 1];
@@ -162,8 +163,11 @@ http_parse_status(HttpResponseState *state, char next)
 }
 
 static void
-http_response_state_add_header(HttpResponseState *state, char *name, int name_len, char
-							   *value, int value_len)
+http_response_state_add_header(HttpResponseState *state,
+							   const char *name,
+							   size_t name_len,
+							   const char *value,
+							   size_t value_len)
 {
 	MemoryContext old = MemoryContextSwitchTo(state->context);
 	HttpHeader *new_header = http_header_create(name, name_len, value, value_len,
@@ -175,7 +179,7 @@ http_response_state_add_header(HttpResponseState *state, char *name, int name_le
 
 static
 void
-http_parse_interm(HttpResponseState *state, char next)
+http_parse_interm(HttpResponseState *state, const char next)
 {
 	int			temp_length;
 
@@ -212,7 +216,7 @@ http_parse_interm(HttpResponseState *state, char next)
 }
 
 static void
-http_parse_header_name(HttpResponseState *state, char next)
+http_parse_header_name(HttpResponseState *state, const char next)
 {
 	switch (next)
 	{
@@ -251,7 +255,7 @@ http_parse_header_name(HttpResponseState *state, char next)
 
 /*  We do not customize to header_name. Assume all non \r or \n chars are allowed. */
 static void
-http_parse_header_value(HttpResponseState *state, char next)
+http_parse_header_value(HttpResponseState *state, const char next)
 {
 	/* Allow everything except... \r, \n */
 	switch (next)
@@ -270,7 +274,7 @@ http_parse_header_value(HttpResponseState *state, char next)
 }
 
 static void
-http_parse_almost_done(HttpResponseState *state, char next)
+http_parse_almost_done(HttpResponseState *state, const char next)
 {
 	/* Don't do anything, this is intermediate state */
 	switch (next)
@@ -289,7 +293,7 @@ http_parse_almost_done(HttpResponseState *state, char next)
 }
 
 bool
-http_response_state_parse(HttpResponseState *state, int bytes)
+http_response_state_parse(HttpResponseState *state, size_t bytes)
 {
 	if (state->offset > MAX_RAW_BUFFER_SIZE)
 		state->offset = MAX_RAW_BUFFER_SIZE;


### PR DESCRIPTION
This fixes two things related to parameter types in the HTTP lib:

- Add `const` to parameter types, such as strings
- Use `size_t` for length parameters